### PR TITLE
Improve makeCircularList function

### DIFF
--- a/ch2.2.4-ex5/circular-list.ts
+++ b/ch2.2.4-ex5/circular-list.ts
@@ -7,10 +7,6 @@ export interface ListNode<T> {
     link: ListNode<T>;
 }
 
-interface ProtoCircularList<T> {
-    ptr: ProtoListNode<T> | NullLink;
-}
-
 interface ProtoListNode<T> {
     info: T;
     link: ProtoListNode<T> | NullLink;
@@ -24,25 +20,28 @@ export const Λ = NullLink.NULL;
 // Builds a circular list from a set of values. Just a convenience
 // function so that we don't have to write the object literals out.
 export function makeCircularList<T>(...values: T[]): CircularList<T> {
-    if (values.length === 0) {
-        return { ptr: Λ };
+    let rightmostNode: ProtoListNode<T> | undefined = undefined;
+    let leftmostNode: ProtoListNode<T> | NullLink = values.reduceRight(
+        (
+            nextNode: ProtoListNode<T> | NullLink,
+            info: T,
+        ): ProtoListNode<T> | NullLink => {
+            let newNode = {
+                info,
+                link: nextNode,
+            };
+            rightmostNode = rightmostNode || newNode;
+            return newNode;
+        },
+        Λ, // overwritten below
+    );
+    // At this point, `rightmostNode`, if it was ever set, will have
+    // its .link pointing to Λ. We want it to instead point to `leftmostNode`.
+    if (rightmostNode) {
+        (rightmostNode as ProtoListNode<T>).link = leftmostNode;
     }
-    let last!: ProtoListNode<T>;
-    let unjoinedCircularList: ProtoCircularList<T> = {
-        ptr: values.reduceRight(
-            (
-                nextNode: ProtoListNode<T> | NullLink,
-                info: T,
-            ): ProtoListNode<T> | NullLink =>
-                (last = last || {
-                    info,
-                    link: nextNode,
-                }),
-            Λ, // overwritten below
-        ),
+    return {
+        // The below conversion is now valid because there is no Λ
+        ptr: (rightmostNode as unknown) as ListNode<T>,
     };
-    let first = unjoinedCircularList.ptr;
-    last.link = first;
-    let circularList: CircularList<T> = unjoinedCircularList as CircularList<T>;
-    return circularList;
 }


### PR DESCRIPTION
The old version is to be considered suspect and buggy.

For one thing, I realized the book wants the `ptr` to point to the
_rightmost_ ("end") node in the circular list. The way I had it in
the previous version, it pointed to the _leftmost_ end. 🤦‍♂ 

But then I also found a way to express things much shorter and clearer.
I got rid of the type `ProtoCircularList`, which simply isn't needed.
I also got rid of the special case of an empty circular list, which
is now simply handled on-the-fly by checking if we even _have_ a
`rightmostNode`. Along the way, we also got more suitable variable
names.

I also discovered I had made a horrible mistake inside the
`reduceRight`, causing the whole `makeCircularList` function not
to work up until this point. Short story: I was trying to do two things
at the same time: (a) setting `rightmostNode` (formerly known as `last`)
and (b) returning a newly created node. Somehow I screwed up the latter.

Yep, I will hand in my "Master" badge and magical Staff of Wisdom at
the front desk, and then walk _on foot_ back home across the desert. 🧙‍♂️