### PR TITLE
Implement solution to ch2.2.1, exercise 2

### DIFF
--- a/ch2.2.1-ex2/operations-to-permutation.ts
+++ b/ch2.2.1-ex2/operations-to-permutation.ts
@@ -1,0 +1,27 @@
+import { Operation } from "./operations";
+
+export class CannotPopEmptyStack extends Error {}
+
+export function opsToPerm(operations: Operation[]): number[] {
+    let nextCarNumber = 1;
+    let permutation: number[] = [];
+    let stack: number[] = [];
+
+    for (let op of operations) {
+        switch (op) {
+            case Operation.S:
+                stack.push(nextCarNumber);
+                nextCarNumber++;
+                break;
+            case Operation.X:
+                let number = stack.pop();
+                if (typeof number === "undefined") {
+                    throw new CannotPopEmptyStack();
+                }
+                permutation.push(number);
+                break;
+        }
+    }
+
+    return permutation;
+}

--- a/ch2.2.1-ex2/operations-to-permutation.ts
+++ b/ch2.2.1-ex2/operations-to-permutation.ts
@@ -1,8 +1,28 @@
 import { Operation } from "./operations";
 
+/** If at any point in the sequence of operations passed to `opsToPerm` we have
+ *  seen more Xs than Ss, this translates to popping an empty stack. That's not
+ *  permissible, and so the sequence of operations as a whole is inadmissible.
+ */
 export class CannotPopEmptyStack extends Error {}
+
+/** If the sequence of operations contains fewer Xs than Ss when it ends, cars
+ *  are still left on the stack, which is not in good taste and hence not
+ *  allowed. (You're allowed only to stack cars which you later unstack.) Thanks
+ *  to this exception, if a sequence of operations is returned, it will always
+ *  have as many Ss as it has Xs.
+ */
 export class CarsLeftOnStack extends Error {}
 
+/** Interprets a sequence of operations and gives back the permutation that
+ * results.
+ *
+ * For example: `SSXSXSXX` results in (2 3 4 1).
+ *
+ * The interpretation can result in `CannotPopEmptyStack` or `CarsLeftOnStack`
+ * (which see) if the sequence of operations does not conform to our
+ * expectations.
+ */
 export function opsToPerm(operations: Operation[]): number[] {
     let nextCarNumber = 1;
     let permutation: number[] = [];

--- a/ch2.2.1-ex2/operations-to-permutation.ts
+++ b/ch2.2.1-ex2/operations-to-permutation.ts
@@ -1,6 +1,7 @@
 import { Operation } from "./operations";
 
 export class CannotPopEmptyStack extends Error {}
+export class CarsLeftOnStack extends Error {}
 
 export function opsToPerm(operations: Operation[]): number[] {
     let nextCarNumber = 1;
@@ -21,6 +22,10 @@ export function opsToPerm(operations: Operation[]): number[] {
                 permutation.push(number);
                 break;
         }
+    }
+
+    if (stack.length) {
+        throw new CarsLeftOnStack();
     }
 
     return permutation;

--- a/ch2.2.1-ex2/operations.ts
+++ b/ch2.2.1-ex2/operations.ts
@@ -1,4 +1,4 @@
 export enum Operation {
-    S = "S",
-    X = "X",
+    S = "S" /** push train car from input to stack */,
+    X = "X" /** pop train car from top of stack; output it */,
 }

--- a/ch2.2.1-ex2/operations.ts
+++ b/ch2.2.1-ex2/operations.ts
@@ -1,0 +1,4 @@
+export enum Operation {
+    S = "S",
+    X = "X",
+}

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -1,7 +1,18 @@
 import { Operation } from "./operations";
 
+/** In general, an array of integers is not a permutation of 1..n. For when it
+ *  isn't, we throw this exception, because the algorithm works under the
+ *  assumption that the input is such a permutation.
+ */
 export class NotAPermutation extends Error {}
 
+/** Cars sometimes get put on the stack in order to immediately be emitted, but
+ *  much of the time they get put on the stack in order to emit some higher-
+ *  numbered car. In this latter case, because the stack is a stack, we're only
+ *  able to emit the cars in the opposite (LIFO) order they were stacked.
+ *  This exception signals that an attempt was made to emit some cars in the
+ *  (FIFO) order they were stacked.
+ */
 export class CannotOutputInOriginalOrder extends Error {
     public firstNumber: number;
     public secondNumber: number;
@@ -27,7 +38,7 @@ export class CannotOutputInOriginalOrder extends Error {
     }
 }
 
-// Returns `true` iff the array is some permutation of [1, 2, ..., n], n >= 1
+/** Returns whether the array is some permutation of [1, 2, ..., n], n >= 1. */
 function isPermutation(array: number[]): boolean {
     return (
         array.length > 0 &&
@@ -35,6 +46,29 @@ function isPermutation(array: number[]): boolean {
     );
 }
 
+/** Given a permutation, returns a sequence of stack operations (if any) that
+ *  will yield that permutation.
+ *
+ *  For example: (2 3 4 1) results in `SSXSXSXX`.
+ *
+ *  If the input is malformed somehow, throws `NotAPermutation`.
+ *
+ *  The following explains the algorithm in all its generality: the next number
+ *  we want to emit is either:
+ *
+ *  - The next number in the input, in which case we just stack it and emit it
+ *    immediately.
+ *
+ *  - Higher than the next number in the input, in which case we need to stack
+ *    all the numbers up to the expected one, and then emit that. (The lower
+ *    numbers remain on the stack.)
+ *
+ *  - Lower than the next number in the input. We can't have emitted it yet,
+ *    since the input is a permutation. Instead, the number must be on the
+ *    stack. X is our only emitting operation, so we can only emit the top of
+ *    the stack. If we try to emit anything else, the function throws
+ *    `CannotOutputInOriginalOrder`.
+ */
 export function permToOps(inputPermutation: number[]): Operation[] {
     if (!isPermutation(inputPermutation)) {
         throw new NotAPermutation();

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -18,5 +18,10 @@ export function permToOps(inputPermutation: number[]): Operation[] {
         throw new NotAPermutation();
     }
 
-    return [Operation.S, Operation.X];
+    let outputOperations = [];
+    for (let number of inputPermutation) {
+        outputOperations.push(Operation.S);
+        outputOperations.push(Operation.X);
+    }
+    return outputOperations;
 }

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -19,8 +19,12 @@ export function permToOps(inputPermutation: number[]): Operation[] {
     }
 
     let outputOperations = [];
+    let nextCarFromInput = 1;
     for (let number of inputPermutation) {
-        outputOperations.push(Operation.S);
+        while (number >= nextCarFromInput) {
+            outputOperations.push(Operation.S);
+            nextCarFromInput++;
+        }
         outputOperations.push(Operation.X);
     }
     return outputOperations;

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -24,7 +24,9 @@ export class CannotOutputInOriginalOrder extends Error {
     public toString(): string {
         return `Can't output ${this.firstNumber} then ${
             this.secondNumber
-        }; these were stacked in order to output ${this.previousHighNumber}`;
+        }; the former was stacked in order to output ${
+            this.previousHighNumber
+        }`;
     }
 }
 
@@ -44,10 +46,12 @@ export function permToOps(inputPermutation: number[]): Operation[] {
     let outputOperations = [];
     let nextCarFromInput = 1;
     let stack = [];
+    let stackingReason = new Map<number, number>();
     for (let number of inputPermutation) {
         while (number >= nextCarFromInput) {
             outputOperations.push(Operation.S);
             stack.push(nextCarFromInput);
+            stackingReason.set(nextCarFromInput, number);
             nextCarFromInput++;
         }
         let stackTop = stack[stack.length - 1];
@@ -55,7 +59,7 @@ export function permToOps(inputPermutation: number[]): Operation[] {
             throw new CannotOutputInOriginalOrder(
                 number,
                 stackTop,
-                nextCarFromInput - 1,
+                stackingReason.get(number) as number,
             );
         }
         outputOperations.push(Operation.X);

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -5,6 +5,23 @@ export enum Operation {
 
 export class NotAPermutation extends Error {}
 
+export class CannotOutputInOriginalOrder extends Error {
+    public firstNumber: number;
+    public secondNumber: number;
+    public previousHighNumber: number;
+
+    public constructor(
+        firstNumber: number,
+        secondNumber: number,
+        previousHighNumber: number,
+    ) {
+        super();
+        this.firstNumber = firstNumber;
+        this.secondNumber = secondNumber;
+        this.previousHighNumber = previousHighNumber;
+    }
+}
+
 // Returns `true` iff the array is some permutation of [1, 2, ..., n], n >= 1
 function isPermutation(array: number[]): boolean {
     return (
@@ -20,12 +37,23 @@ export function permToOps(inputPermutation: number[]): Operation[] {
 
     let outputOperations = [];
     let nextCarFromInput = 1;
+    let stack = [];
     for (let number of inputPermutation) {
         while (number >= nextCarFromInput) {
             outputOperations.push(Operation.S);
+            stack.push(nextCarFromInput);
             nextCarFromInput++;
         }
+        let stackTop = stack[stack.length - 1];
+        if (number !== stackTop) {
+            throw new CannotOutputInOriginalOrder(
+                number,
+                stackTop,
+                nextCarFromInput - 1,
+            );
+        }
         outputOperations.push(Operation.X);
+        stack.pop();
     }
     return outputOperations;
 }

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -48,6 +48,13 @@ export function permToOps(inputPermutation: number[]): Operation[] {
     let stack = [];
     let stackingReason = new Map<number, number>();
     for (let number of inputPermutation) {
+        // CASE I(a): The number we're to output is the next one from the input.
+        //            In this case we go through the below loop once, and we're
+        //            guaranteed success afterwards. No net change to the stack.
+        // CASE I(b): The number we're to output is higher than the next one
+        //            from the input. In this case we need to stack all the
+        //            numbers we're not ready to output yet. They'll be stacked
+        //            so they need to be output in reverse (LIFO) order later.
         while (number >= nextCarFromInput) {
             outputOperations.push(Operation.S);
             stack.push(nextCarFromInput);
@@ -55,6 +62,11 @@ export function permToOps(inputPermutation: number[]): Operation[] {
             nextCarFromInput++;
         }
         let stackTop = stack[stack.length - 1];
+        // CASE II(a): The number we're to output is somewhere in the stack, but
+        //             not on top. This in the only thing we can't do, and we
+        //             need to throw an exception rather than continue. This
+        //             happens when cars were stacked in I(b) earlier, and now
+        //             they're requested in some non-LIFO order.
         if (number !== stackTop) {
             throw new CannotOutputInOriginalOrder(
                 number,
@@ -62,6 +74,11 @@ export function permToOps(inputPermutation: number[]): Operation[] {
                 stackingReason.get(number) as number,
             );
         }
+        // CASE II(b): The number we're to output is on the top of the stack.
+        //             Either because we're coming directly from case I(a), or
+        //             because things were stacked in a previous iterations's
+        //             step I(b), and they're now being requested in a LIFO
+        //             order.
         outputOperations.push(Operation.X);
         stack.pop();
     }

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -1,7 +1,4 @@
-export enum Operation {
-    S = "S",
-    X = "X",
-}
+import { Operation } from "./operations";
 
 export class NotAPermutation extends Error {}
 

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -20,6 +20,12 @@ export class CannotOutputInOriginalOrder extends Error {
         this.secondNumber = secondNumber;
         this.previousHighNumber = previousHighNumber;
     }
+
+    public toString(): string {
+        return `Can't output ${this.firstNumber} then ${
+            this.secondNumber
+        }; these were stacked in order to output ${this.previousHighNumber}`;
+    }
 }
 
 // Returns `true` iff the array is some permutation of [1, 2, ..., n], n >= 1

--- a/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/ch2.2.1-ex2/permutation-to-operations.ts
@@ -1,0 +1,22 @@
+export enum Operation {
+    S = "S",
+    X = "X",
+}
+
+export class NotAPermutation extends Error {}
+
+// Returns `true` iff the array is some permutation of [1, 2, ..., n], n >= 1
+function isPermutation(array: number[]): boolean {
+    return (
+        array.length > 0 &&
+        array.every((_, i): boolean => array.includes(i + 1))
+    );
+}
+
+export function permToOps(inputPermutation: number[]): Operation[] {
+    if (!isPermutation(inputPermutation)) {
+        throw new NotAPermutation();
+    }
+
+    return [Operation.S, Operation.X];
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"scripts": {
 		"test": "tsc && ava",
-		"lint": "eslint ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts",
-		"prettier": "prettier --write ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts"
+		"lint": "eslint ch2.2.1-ex2/*.ts test/ch2.2.1-ex2/*.ts ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts",
+		"prettier": "prettier --write ch2.2.1-ex2/*.ts test/ch2.2.1-ex2/*.ts ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "1.9.0",

--- a/test/ch2.2.1-ex2/operations-to-permutation.ts
+++ b/test/ch2.2.1-ex2/operations-to-permutation.ts
@@ -17,3 +17,24 @@ test("cannot pop an empty stack", (t): void => {
 
     t.throws((): number[] => opsToPerm([S, X, X]), CannotPopEmptyStack);
 });
+
+test("letting through two train cars", (t): void => {
+    t.deepEqual([1, 2], opsToPerm([S, X, S, X]));
+});
+
+test("stacking cars; output in reverse", (t): void => {
+    t.deepEqual([2, 1], opsToPerm([S, S, X, X]));
+    t.deepEqual([3, 2, 1], opsToPerm([S, S, S, X, X, X]));
+    t.deepEqual([1, 3, 2], opsToPerm([S, X, S, S, X, X]));
+});
+
+test("example 1/3 from the exercise", (t): void => {
+    t.deepEqual([2, 4, 3, 1], opsToPerm([S, S, X, S, S, X, X, X]));
+});
+
+test("example 2/3 from the exercise", (t): void => {
+    t.deepEqual(
+        [3, 2, 5, 6, 4, 1],
+        opsToPerm([S, S, S, X, X, S, S, X, S, X, X, X]),
+    );
+});

--- a/test/ch2.2.1-ex2/operations-to-permutation.ts
+++ b/test/ch2.2.1-ex2/operations-to-permutation.ts
@@ -1,0 +1,19 @@
+import test from "ava";
+import { Operation } from "../../ch2.2.1-ex2/operations";
+import {
+    opsToPerm,
+    CannotPopEmptyStack,
+} from "../../ch2.2.1-ex2/operations-to-permutation";
+
+const S = Operation.S;
+const X = Operation.X;
+
+test("letting through one train car", (t): void => {
+    t.deepEqual([1], opsToPerm([S, X]));
+});
+
+test("cannot pop an empty stack", (t): void => {
+    t.throws((): number[] => opsToPerm([X]), CannotPopEmptyStack);
+
+    t.throws((): number[] => opsToPerm([S, X, X]), CannotPopEmptyStack);
+});

--- a/test/ch2.2.1-ex2/operations-to-permutation.ts
+++ b/test/ch2.2.1-ex2/operations-to-permutation.ts
@@ -3,6 +3,7 @@ import { Operation } from "../../ch2.2.1-ex2/operations";
 import {
     opsToPerm,
     CannotPopEmptyStack,
+    CarsLeftOnStack,
 } from "../../ch2.2.1-ex2/operations-to-permutation";
 
 const S = Operation.S;
@@ -37,4 +38,10 @@ test("example 2/3 from the exercise", (t): void => {
         [3, 2, 5, 6, 4, 1],
         opsToPerm([S, S, S, X, X, S, S, X, S, X, X, X]),
     );
+});
+
+test("cars left on the stack", (t): void => {
+    t.throws((): number[] => opsToPerm([S]), CarsLeftOnStack);
+    t.throws((): number[] => opsToPerm([S, X, S]), CarsLeftOnStack);
+    t.throws((): number[] => opsToPerm([S, S, X]), CarsLeftOnStack);
 });

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -31,3 +31,7 @@ test("not a permutation", (t): void => {
         "Permutation can't have duplicates",
     );
 });
+
+test("letting through two train cars", (t): void => {
+    t.deepEqual([S, X, S, X], permToOps([1, 2]));
+});

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -65,5 +65,9 @@ test("can't output stacked cars in original order", (t): void => {
         t.is(ex.firstNumber, 1);
         t.is(ex.secondNumber, 2);
         t.is(ex.previousHighNumber, 3);
+        t.is(
+            ex.toString(),
+            "Can't output 1 then 2; these were stacked in order to output 3",
+        );
     }
 });

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -67,7 +67,25 @@ test("can't output stacked cars in original order", (t): void => {
         t.is(ex.previousHighNumber, 3);
         t.is(
             ex.toString(),
-            "Can't output 1 then 2; these were stacked in order to output 3",
+            "Can't output 1 then 2; the former was stacked in order to output 3",
+        );
+    }
+});
+
+test("example 3/3 from the exercise", (t): void => {
+    try {
+        permToOps([1, 5, 4, 6, 2, 3]);
+        t.fail("should've thrown an exception");
+    } catch (ex) {
+        if (!(ex instanceof CannotOutputInOriginalOrder)) {
+            throw ex;
+        }
+        t.is(ex.firstNumber, 2);
+        t.is(ex.secondNumber, 3);
+        t.is(ex.previousHighNumber, 5);
+        t.is(
+            ex.toString(),
+            "Can't output 2 then 3; the former was stacked in order to output 5",
         );
     }
 });

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -35,3 +35,9 @@ test("not a permutation", (t): void => {
 test("letting through two train cars", (t): void => {
     t.deepEqual([S, X, S, X], permToOps([1, 2]));
 });
+
+test("stacking cars; output in reverse", (t): void => {
+    t.deepEqual([S, S, X, X], permToOps([2, 1]));
+    t.deepEqual([S, S, S, X, X, X], permToOps([3, 2, 1]));
+    t.deepEqual([S, X, S, S, X, X], permToOps([1, 3, 2]));
+});

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -1,0 +1,33 @@
+import test from "ava";
+import {
+    Operation,
+    NotAPermutation,
+    permToOps,
+} from "../../ch2.2.1-ex2/permutation-to-operations";
+
+const S = Operation.S;
+const X = Operation.X;
+
+test("letting through one train car", (t): void => {
+    t.deepEqual([S, X], permToOps([1]));
+});
+
+test("not a permutation", (t): void => {
+    t.throws(
+        (): Operation[] => permToOps([]),
+        NotAPermutation,
+        "Permutation can't be empty",
+    );
+
+    t.throws(
+        (): Operation[] => permToOps([2, 3]),
+        NotAPermutation,
+        "Permutation can't be missing numbers",
+    );
+
+    t.throws(
+        (): Operation[] => permToOps([1, 1]),
+        NotAPermutation,
+        "Permutation can't have duplicates",
+    );
+});

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -45,3 +45,10 @@ test("stacking cars; output in reverse", (t): void => {
 test("example 1/3 from the exercise", (t): void => {
     t.deepEqual([S, S, X, S, S, X, X, X], permToOps([2, 4, 3, 1]));
 });
+
+test("example 2/3 from the exercise", (t): void => {
+    t.deepEqual(
+        [S, S, S, X, X, S, S, X, S, X, X, X],
+        permToOps([3, 2, 5, 6, 4, 1]),
+    );
+});

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -2,6 +2,7 @@ import test from "ava";
 import {
     Operation,
     NotAPermutation,
+    CannotOutputInOriginalOrder,
     permToOps,
 } from "../../ch2.2.1-ex2/permutation-to-operations";
 
@@ -51,4 +52,18 @@ test("example 2/3 from the exercise", (t): void => {
         [S, S, S, X, X, S, S, X, S, X, X, X],
         permToOps([3, 2, 5, 6, 4, 1]),
     );
+});
+
+test("can't output stacked cars in original order", (t): void => {
+    try {
+        permToOps([3, 1, 2]);
+        t.fail("should've thrown an exception");
+    } catch (ex) {
+        if (!(ex instanceof CannotOutputInOriginalOrder)) {
+            throw ex;
+        }
+        t.is(ex.firstNumber, 1);
+        t.is(ex.secondNumber, 2);
+        t.is(ex.previousHighNumber, 3);
+    }
 });

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -1,6 +1,6 @@
 import test from "ava";
+import { Operation } from "../../ch2.2.1-ex2/operations";
 import {
-    Operation,
     NotAPermutation,
     CannotOutputInOriginalOrder,
     permToOps,

--- a/test/ch2.2.1-ex2/permutation-to-operations.ts
+++ b/test/ch2.2.1-ex2/permutation-to-operations.ts
@@ -41,3 +41,7 @@ test("stacking cars; output in reverse", (t): void => {
     t.deepEqual([S, S, S, X, X, X], permToOps([3, 2, 1]));
     t.deepEqual([S, X, S, S, X, X], permToOps([1, 3, 2]));
 });
+
+test("example 1/3 from the exercise", (t): void => {
+    t.deepEqual([S, S, X, S, S, X, X, X], permToOps([2, 4, 3, 1]));
+});


### PR DESCRIPTION
Exercise 2 from chapter 2.2.1 is most likely meant to be worked out by hand; this PR works it out by algorithm.

* The function `permToOps` takes a permutation of the numbers (1, 2, ... n) as input, and either
    * (a) emits a sequence of `S` (push) and `X` (pop) operations that will generate this permutation, or
    * (b) explains exactly why it cannot be done
* For good form, the function `opsToPerm` does the slightly simpler job of going the other way: given a sequence of `S` and `X` operations, it simulates the effects they would have on a stack, and the resulting permutation given by the order the train cars are popped.

The most interesting bit of this code is probably the commented bits in `permToOps`, which goes through all possible cases when deriving the next operation from the next part of the input permutation. The case II(a) is the one that leads to the exception `CannotOutputInOriginalOrder`. This happens when an _earlier_ train car had a higher number and so the lower numbers had to be stacked, but now they are being requested out in increasing order, which is impossible with a stack. For example, the permutation `[3, 2, 1]` is not a problem, but `[3, 1, 2]` is impossible. This is the smallest example; any permutation `[..., c, ..., a, ..., b, ...]`, with `a < b < c` will exhibit the same problem. The exception `CannotOutputInOriginalOrder` takes pains to find the numbers `a`, `b`, and `c` and put them in the exception object along with a nice message.