### PR TITLE
Solution to part 1 of ch2.2.1-ex3

### DIFF
--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -4,8 +4,7 @@ export function sequenceIsAdmissible(sequence: Operation[]): boolean {
     let stackSize = 0;
 
     for (let op of sequence) {
-        stackSize += op === Operation.S ? +1 : -1;
-        if (stackSize < 0) {
+        if ((stackSize += op === Operation.S ? +1 : -1) < 0) {
             return false;
         }
     }

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -1,0 +1,11 @@
+import { Operation } from "../ch2.2.1-ex2/operations";
+import { opsToPerm } from "../ch2.2.1-ex2/operations-to-permutation";
+
+export function sequenceIsAdmissible(sequence: Operation[]): boolean {
+    try {
+        opsToPerm(sequence);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -2,12 +2,9 @@ import { Operation } from "../ch2.2.1-ex2/operations";
 
 export function sequenceIsAdmissible(sequence: Operation[]): boolean {
     let stackSize = 0;
-
-    for (let op of sequence) {
-        if ((stackSize += op === Operation.S ? +1 : -1) < 0) {
-            return false;
-        }
-    }
-
-    return !stackSize;
+    return (
+        sequence.every(
+            (op): boolean => (stackSize += op === Operation.S ? +1 : -1) >= 0,
+        ) && !stackSize
+    );
 }

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -1,8 +1,4 @@
 import { Operation } from "../ch2.2.1-ex2/operations";
-import {
-    CannotPopEmptyStack,
-    CarsLeftOnStack,
-} from "../ch2.2.1-ex2/operations-to-permutation";
 
 export function sequenceIsAdmissible(sequence: Operation[]): boolean {
     try {
@@ -18,14 +14,14 @@ export function sequenceIsAdmissible(sequence: Operation[]): boolean {
                 case Operation.X:
                     let number = stack.pop();
                     if (typeof number === "undefined") {
-                        throw new CannotPopEmptyStack();
+                        return false;
                     }
                     break;
             }
         }
 
         if (stack.length) {
-            throw new CarsLeftOnStack();
+            return false;
         }
 
         return true;

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -10,10 +10,10 @@ export function sequenceIsAdmissible(sequence: Operation[]): boolean {
                 break;
             case Operation.X:
                 stackSize -= 1;
-                if (stackSize < 0) {
-                    return false;
-                }
                 break;
+        }
+        if (stackSize < 0) {
+            return false;
         }
     }
 

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -1,31 +1,27 @@
 import { Operation } from "../ch2.2.1-ex2/operations";
 
 export function sequenceIsAdmissible(sequence: Operation[]): boolean {
-    try {
-        let nextCarNumber = 1;
-        let stack: number[] = [];
+    let nextCarNumber = 1;
+    let stack: number[] = [];
 
-        for (let op of sequence) {
-            switch (op) {
-                case Operation.S:
-                    stack.push(nextCarNumber);
-                    nextCarNumber++;
-                    break;
-                case Operation.X:
-                    let number = stack.pop();
-                    if (typeof number === "undefined") {
-                        return false;
-                    }
-                    break;
-            }
+    for (let op of sequence) {
+        switch (op) {
+            case Operation.S:
+                stack.push(nextCarNumber);
+                nextCarNumber++;
+                break;
+            case Operation.X:
+                let number = stack.pop();
+                if (typeof number === "undefined") {
+                    return false;
+                }
+                break;
         }
+    }
 
-        if (stack.length) {
-            return false;
-        }
-
-        return true;
-    } catch {
+    if (stack.length) {
         return false;
     }
+
+    return true;
 }

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -2,22 +2,22 @@ import { Operation } from "../ch2.2.1-ex2/operations";
 
 export function sequenceIsAdmissible(sequence: Operation[]): boolean {
     let nextCarNumber = 1;
-    let stack: number[] = [];
+    let stackSize = 0;
 
     for (let op of sequence) {
         switch (op) {
             case Operation.S:
-                stack.push(nextCarNumber);
+                stackSize += 1;
                 nextCarNumber++;
                 break;
             case Operation.X:
-                let number = stack.pop();
-                if (typeof number === "undefined") {
+                stackSize -= 1;
+                if (stackSize < 0) {
                     return false;
                 }
                 break;
         }
     }
 
-    return !stack.length;
+    return !stackSize;
 }

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -4,14 +4,7 @@ export function sequenceIsAdmissible(sequence: Operation[]): boolean {
     let stackSize = 0;
 
     for (let op of sequence) {
-        switch (op) {
-            case Operation.S:
-                stackSize += 1;
-                break;
-            case Operation.X:
-                stackSize -= 1;
-                break;
-        }
+        stackSize += op === Operation.S ? +1 : -1;
         if (stackSize < 0) {
             return false;
         }

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -7,7 +7,6 @@ import {
 export function sequenceIsAdmissible(sequence: Operation[]): boolean {
     try {
         let nextCarNumber = 1;
-        let permutation: number[] = [];
         let stack: number[] = [];
 
         for (let op of sequence) {
@@ -21,7 +20,6 @@ export function sequenceIsAdmissible(sequence: Operation[]): boolean {
                     if (typeof number === "undefined") {
                         throw new CannotPopEmptyStack();
                     }
-                    permutation.push(number);
                     break;
             }
         }

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -1,14 +1,12 @@
 import { Operation } from "../ch2.2.1-ex2/operations";
 
 export function sequenceIsAdmissible(sequence: Operation[]): boolean {
-    let nextCarNumber = 1;
     let stackSize = 0;
 
     for (let op of sequence) {
         switch (op) {
             case Operation.S:
                 stackSize += 1;
-                nextCarNumber++;
                 break;
             case Operation.X:
                 stackSize -= 1;

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -19,9 +19,5 @@ export function sequenceIsAdmissible(sequence: Operation[]): boolean {
         }
     }
 
-    if (stack.length) {
-        return false;
-    }
-
-    return true;
+    return !stack.length;
 }

--- a/ch2.2.1-ex3/admissible.ts
+++ b/ch2.2.1-ex3/admissible.ts
@@ -1,9 +1,35 @@
 import { Operation } from "../ch2.2.1-ex2/operations";
-import { opsToPerm } from "../ch2.2.1-ex2/operations-to-permutation";
+import {
+    CannotPopEmptyStack,
+    CarsLeftOnStack,
+} from "../ch2.2.1-ex2/operations-to-permutation";
 
 export function sequenceIsAdmissible(sequence: Operation[]): boolean {
     try {
-        opsToPerm(sequence);
+        let nextCarNumber = 1;
+        let permutation: number[] = [];
+        let stack: number[] = [];
+
+        for (let op of sequence) {
+            switch (op) {
+                case Operation.S:
+                    stack.push(nextCarNumber);
+                    nextCarNumber++;
+                    break;
+                case Operation.X:
+                    let number = stack.pop();
+                    if (typeof number === "undefined") {
+                        throw new CannotPopEmptyStack();
+                    }
+                    permutation.push(number);
+                    break;
+            }
+        }
+
+        if (stack.length) {
+            throw new CarsLeftOnStack();
+        }
+
         return true;
     } catch {
         return false;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"scripts": {
 		"test": "tsc && ava",
-		"lint": "eslint ch2.2.1-ex2/*.ts test/ch2.2.1-ex2/*.ts ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts",
-		"prettier": "prettier --write ch2.2.1-ex2/*.ts test/ch2.2.1-ex2/*.ts ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts"
+		"lint": "eslint ch2.2.1-ex2/*.ts test/ch2.2.1-ex2/*.ts ch2.2.1-ex3/*.ts test/ch2.2.1-ex3/*.ts ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts",
+		"prettier": "prettier --write ch2.2.1-ex2/*.ts test/ch2.2.1-ex2/*.ts ch2.2.1-ex3/*.ts test/ch2.2.1-ex3/*.ts ch2.2.3-ex7/*.ts test/ch2.2.3-ex7/*.ts ch2.2.4-ex5/*.ts"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "1.9.0",

--- a/test/ch2.2.1-ex3/admissible.ts
+++ b/test/ch2.2.1-ex3/admissible.ts
@@ -1,0 +1,39 @@
+import test from "ava";
+import { Operation } from "../../ch2.2.1-ex2/operations";
+import { sequenceIsAdmissible } from "../../ch2.2.1-ex3/admissible";
+
+const S = Operation.S;
+const X = Operation.X;
+
+test("letting through one train car", (t): void => {
+    t.true(sequenceIsAdmissible([S, X]));
+});
+
+test("cannot pop an empty stack", (t): void => {
+    t.false(sequenceIsAdmissible([X]));
+    t.false(sequenceIsAdmissible([S, X, X]));
+});
+
+test("letting through two train cars", (t): void => {
+    t.true(sequenceIsAdmissible([S, X, S, X]));
+});
+
+test("stacking cars; output in reverse", (t): void => {
+    t.true(sequenceIsAdmissible([S, S, X, X]));
+    t.true(sequenceIsAdmissible([S, S, S, X, X, X]));
+    t.true(sequenceIsAdmissible([S, X, S, S, X, X]));
+});
+
+test("example 1/3 from the exercise", (t): void => {
+    t.true(sequenceIsAdmissible([S, S, X, S, S, X, X, X]));
+});
+
+test("example 2/3 from the exercise", (t): void => {
+    t.true(sequenceIsAdmissible([S, S, S, X, X, S, S, X, S, X, X, X]));
+});
+
+test("cars left on the stack", (t): void => {
+    t.false(sequenceIsAdmissible([S]));
+    t.false(sequenceIsAdmissible([S, X, S]));
+    t.false(sequenceIsAdmissible([S, S, X]));
+});


### PR DESCRIPTION
The exercise says "Formulate a rule by which it is easy to distinguish between admissible and inadmissible sequences". This PR formulates such a rule. In prose, the rule is:

> At no point while reading the sequence from left to right will we have read more Xs than Ss. Also, the number of Ss and Xs is equal.

The algorithm does this by keeping a running difference `count(S) - count(X)`, and checking that it never becomes lower than 0. Finally, it checks that it's exactly 0 at the end.

I made a point of showing how the `isSequenceAdmissible` can be _derived_ from the earlier `opsToPerm` function. The commit history starts out by delegating to the latter, and then inlining it and eating away at data and control that we no longer need for this simpler task. In some sense `isSequenceAdmissible` is a "projection" of `opsToPerm`.

(The exercise also asks us to prove the uniqueness of each output permutation. This PR does not address that.)