### PR TITLE
Implement ch2.2.1-ex3 (admissible sequences) in Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,20 @@ Or you can compile the script with `csc` and run the resulting binary:
 csc my-script.scm
 ./my-script
 ```
+
+## Setting up GHC
+
+The Haskell solutions have been confirmed to run on [The Glorious Glasgow Haskell Compilation
+System (GHC)](https://www.haskell.org/ghc/), version 8.0.1.
+On Debian/Ubuntu systems, it can be installed via apt:
+
+```
+sudo apt-get install ghc
+```
+
+To compile and run a Haskell script, use the `ghc` binary:
+
+```
+ghc my-script.hs
+./my-script
+```

--- a/ch2.2.1-ex3/admissible.hs
+++ b/ch2.2.1-ex3/admissible.hs
@@ -1,0 +1,17 @@
+import Control.Monad
+import Text.Printf
+
+admissible :: String -> Bool
+admissible = check 0
+    where check :: Int -> String -> Bool
+          check    n       [] = n == 0
+          check (-1)        _ = False
+          check    n ('S':bs) = check (n+1) bs
+          check    n ('X':bs) = check (n-1) bs
+
+sequences :: [String]
+sequences = ["SSXSSXXX", "SXXSSXXS"]
+
+main :: IO ()
+main = do
+    forM_ sequences (\s -> printf "%s: %s" s (show (admissible s)))


### PR DESCRIPTION
I've been carrying _stuff_ all day in the apartment, so I went looking for something suitably abstract to do in the evening.

This is a port of [the TypeScript version](https://github.com/masak/taocp/blob/8ac44e06899d54111657146189e259098817a360/ch2.2.1-ex3/admissible.ts). Like that version, this one makes only a single pass over the input. Unlike that version, this one is Fully Recursive™ and shows a different side of the solution.