### PR TITLE
Add a proof to chapter 1.2.1 exercise 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules/
 *.js
 *.js.map
+*.aux
+*.log
+*.pdf

--- a/README.md
+++ b/README.md
@@ -74,3 +74,18 @@ To compile and run a Haskell script, use the `ghc` binary:
 ghc my-script.hs
 ./my-script
 ```
+
+## Setting up LaTeX
+
+The LaTeX files have been confirmed to build with `pdflatex`.
+On Debian/Ubuntu systems, it can be installed via apt:
+
+```
+sudo apt-get install texlive
+```
+
+To produce a PDF from a LaTeX source file, use the `pdflatex` binary:
+
+```
+pdflatex my-latex-file.tex
+```

--- a/ch1.2.1-ex5/proof.tex
+++ b/ch1.2.1-ex5/proof.tex
@@ -1,0 +1,43 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[english]{babel}
+
+\usepackage{amsthm}
+
+\newtheorem{theorem}{Theorem}
+
+\begin{document}
+
+\begin{theorem}
+All integers $> 1$ can be written as a product of one or more prime numbers.
+\end{theorem}
+
+\begin{proof}
+
+We proceed by induction on the integer $n$.
+
+\textbf{Base case}:
+2 is prime, and so it can be written as a product of one or more primes.
+
+\textbf{Inductive case}:
+By assumption, we've shown that $2 \ldots n - 1$ can all be written as products of one or more prime numbers.
+Let's now examine $n$.
+
+\begin{itemize}
+
+\item
+\textbf{Case I}: $n$ is prime.
+In this case, we are done; $n$ can be written as a product of one or more prime numbers.
+
+\item
+\textbf{Case II}: $n$ is not prime.
+By definition of ``prime'', this means that $n$ \textit{does} have a divisor other than itself and $1$.
+Let's name this divisor $p$.
+Then there's also a number $q$ such that $p q = n$.
+$p$ and $q$ can each be written as a product of one or more prime numbers; juxtaposing these gives $n$ as a product of primes.
+
+\end{itemize}
+
+\end{proof}
+
+\end{document}


### PR DESCRIPTION
I tried to be a bit minimal in the proof; I hope I didn't lose any clarity doing so.

For comparison, here I include the proof I wrote last time, as a text file. That one is a bit more explicit.

```
Exercise 5 [21]
A _prime number_ is an integer > 1 that has no exact divisors other than 1 and itself.
Using this definition and mathematical induction, prove that every integer > 1 may be written as a product of one or more prime numbers.
(A prime number is considered to be the "product" of a single number, namely itself.)

Base case: 2 is a prime number, and so a product of one or more prime numbers.

Inductive case: n > 2.

By induction, we have that each of the numbers k, 2≤k<n can be written as a product of one or more prime numbers.

We want to show that n can be written as a product of one or more prime numbers. There are two cases to consider:

* Case A: n is a prime number. In that case we are done, as it's already a product of one or more prime numbers.

* Case B: n is a composite number. Which is to say, _some_ factor p≥2 divides into n.
  Let's call the remaining factor q, so n = pq.
  We don't know much about p and q themselves; in particular, we can't assume that they are both primes (in which case we'd be done).
  But we _can_ assume that they are both ≤ n. (Why? Because either can be at most (n+1)/2, which is < n since n ≥ 2.)
  So p (by induction) can be written as a product of one or more primes, say p₁p₂...pₛ.
  And q (by induction) can be written as a product of one or more primes, say q₁q₂...qₜ.
Concatenating these two products together, we have expressed n as p₁p₂...pₛq₁q₂...qₜ, a product of one or more primes. ∎
```