### PR TITLE
Add answer to chapter 1.2.4 exercise 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules/
 *.js
 *.js.map
+*.aux
+*.log
+*.pdf

--- a/README.md
+++ b/README.md
@@ -74,3 +74,18 @@ To compile and run a Haskell script, use the `ghc` binary:
 ghc my-script.hs
 ./my-script
 ```
+
+## Setting up LaTeX
+
+The LaTeX files have been confirmed to build with `pdflatex`.
+On Debian/Ubuntu systems, it can be installed via apt:
+
+```
+sudo apt-get install texlive
+```
+
+To produce a PDF from a LaTeX source file, use the `pdflatex` binary:
+
+```
+pdflatex my-latex-file.tex
+```

--- a/ch1.2.4-ex14/answer.tex
+++ b/ch1.2.4-ex14/answer.tex
@@ -1,0 +1,51 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[english]{babel}
+\usepackage{amsmath}
+
+\begin{document}
+
+We are given the two modular identities
+
+\begin{align*}
+x \bmod 3 &= 2 \\
+x \bmod 5 &= 3
+\end{align*}
+The first thing we would like to do is to put them on ``common moduli''.
+Law C allows us to do so:
+
+\begin{align*}
+5 x \bmod 15 &= 10 \\
+3 x \bmod 15 &= 9
+\end{align*}
+Subtracting one from the other (using Law A):
+
+\begin{equation*}
+2 x \bmod 15 = 1
+\end{equation*}
+We are almost there; we'd like to get the $x$ alone on the left side.
+If we were dealing with rationals or reals, we would just divide both sides by $2$ and be done.
+But this is modular arithmetic; there isn't a division operation as such.
+There is, however, the modular inverse of $2$, and we can multiply both sides by it.
+Since $2 * 8 \equiv 1 \pmod{15}$, $8$ is the modular inverse of $2$.
+Therefore,
+
+\begin{equation*}
+x \bmod 15 = 8
+\end{equation*}
+Done.
+
+But wait!
+How did we find that $8$, exactly?
+By all accounts, we just pulled it like a rabbit out of a hat.
+If we wanted to find it the hard way, we could scan for it among all the 15 possible values --- but that's not so elegant.
+The extended Euclid's algorithm allows us to find it in just a few steps with these inputs:
+
+\begin{equation*}
+a m + b n = 1
+\end{equation*}
+In our case, $m = 2$, $n = 15$, and Euclid's algorithm gives us $a$ (and $b$) as output.
+The file \texttt{modular.hs} contains a program with a demonstration of this solution.
+Its function \texttt{modularInverse} has been simplified to not even compute $b$, as we don't care about it.
+
+\end{document}

--- a/ch1.2.4-ex14/modular.hs
+++ b/ch1.2.4-ex14/modular.hs
@@ -1,0 +1,42 @@
+import System.IO (hFlush, stdout)
+
+combinedRemainder :: Int -> Int -> Int -> Int -> Int
+combinedRemainder m n mr nr = (d2 * (modularInverse d1 mn)) `mod` mn
+    where
+        d1 = n - m
+        d2 = mr * n - nr * m
+        mn = m * n
+
+modularInverse :: Int -> Int -> Int
+modularInverse m n = go 1 0 m n
+    where
+        go :: Int -> Int -> Int -> Int -> Int
+        go a' a c d = let (q, r) = c `divMod` d
+            in case r of
+                0 -> a
+                _ -> go a (a' - q * a) d r
+
+main :: IO ()
+main = do
+    m <- prompt "Value of m: "
+    n <- prompt "Value of n: "
+    if coprime m n then
+        askForRemainders (min m n) (max m n)
+        else error "The two values need to be coprime"
+    where
+        prompt :: String -> IO Int
+        prompt query = do
+            putStr query
+            hFlush stdout
+            readLn :: IO Int
+
+        coprime :: Int -> Int -> Bool
+        coprime m n = gcd m n == 1
+
+        askForRemainders :: Int -> Int -> IO ()
+        askForRemainders m n = do
+            let mn = m * n
+            mr <- prompt ("x mod " ++ (show m) ++ " = ")
+            nr <- prompt ("x mod " ++ (show n) ++ " = ")
+            let mnr = combinedRemainder m n mr nr
+            putStrLn ("x mod " ++ (show mn) ++ " = " ++ (show mnr))


### PR DESCRIPTION
This exercise caught my fancy. [I have a fondness for modular arithmetic](https://github.com/masak/alma/blob/e02a3382d0236ac664430e5c757027660048dea9/examples/nicomachus.alma).

The interesting thing to me is the [modular inverse](https://en.wikipedia.org/wiki/Modular_inverse) &mdash; at the end of the solution, we need to find the modular inverse of a number. (Kind of modular arithmetic's analogue to division.) Where we could find this inverse by brute force, in linear time, we can instead do it using the Extended Euclid's algorithm (described in chapter 1.2.1). This only takes logarithmic time (as mentioned on page 7).